### PR TITLE
Refactor data selection

### DIFF
--- a/yt_geotiff/data_structures.py
+++ b/yt_geotiff/data_structures.py
@@ -6,10 +6,11 @@ import stat
 
 from yt.data_objects.static_output import \
     Dataset
-
 from yt.data_objects.selection_objects.data_selection_objects import (
     YTSelectionContainer,
-)    
+)
+from yt.geometry.selection_routines import \
+    GridSelector
 from yt.frontends.ytdata.data_structures import \
     YTGridHierarchy, \
     YTGrid
@@ -55,11 +56,15 @@ class GeoTiffWindowGrid(YTGrid):
 
 class GeoTiffGrid(YTGrid):
     def select(self, selector, source, dest, offset):
+        if isinstance(selector, GridSelector):
+            return super().select(selector, source, dest, offset)
         wgrid = self._get_window_grid(selector)
         rvalue = wgrid.select(selector, source, dest, offset)
         return rvalue
 
     def count(self, selector):
+        if isinstance(selector, GridSelector):
+            return super().count(selector)
         wgrid = self._get_window_grid(selector)
         rvalue = wgrid.count(selector)
         return rvalue

--- a/yt_geotiff/io.py
+++ b/yt_geotiff/io.py
@@ -70,8 +70,9 @@ class IOHandlerGeoTiff(IOHandlerYTGridHDF5):
                 left_edge, right_edge, width, height = rasterio_window_calc(selector)
 
                 # Build Rasterio window-read format
-                rasterio_wr_dim = Window((left_edge[0]/src.res[0]), (right_edge[0]/src.res[0]),
-                                         (width/src.res[0]), (height/src.res[0]))
+                rasterio_wr_dim = Window(
+                    left_edge[0]/src.res[0], left_edge[1]/src.res[1],
+                    width/src.res[0], height/src.res[1])
 
                 for field in fields:
                     if field in gf:   # only for cached gridded objects
@@ -90,7 +91,8 @@ class IOHandlerGeoTiff(IOHandlerYTGridHDF5):
                     ftype, fname = field
 
                     # Perform Rasterio window read
-                    data = src.read(int(fname),window=rasterio_wr_dim).astype(self._field_dtype)
+                    data = src.read(int(fname),window=rasterio_wr_dim).astype(
+                        self._field_dtype)
 
                     for dim in range(len(data.shape), 3): # change to 3d
                         data = np.expand_dims(data, dim)
@@ -99,10 +101,7 @@ class IOHandlerGeoTiff(IOHandlerYTGridHDF5):
                         self._cached_fields.setdefault(g.id, {})
                         self._cached_fields[g.id][field] = data
 
-                    # Create a temporary GeoTiffWindowGrid object that matches the selector dimensions
-                    nd = g.select(selector, data, rv[field], ind,
-                                  left_edge, right_edge,
-                                  np.array([int(width/src.res[0]), int(height/src.res[0]), 1]))
+                    nd = g.select(selector, data, rv[field], ind)
 
                 ind += nd
 


### PR DESCRIPTION
This PR has a few enhancements and a bugfix:
- refactor calculation of domain left/right edge and dimensions to use the rasterio transform
- [bugfix] use left_x, left_y instead of left_x, right_x in rasterio window read
- refactor use of temporary window grid to make it easier to implement other grid methods
- implement grid.count method using the temporary window grid

The last item speeds up querying the large geotiff files from a minute or more down to less than a second and should now make this performant with a regular windowed read.