### PR TITLE
[bugfix] use correct rasterio window

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ lib64/
 parts/
 sdist/
 var/
+.ipynb_checkpoints/
 *.egg-info/
 .installed.cfg
 *.egg

--- a/yt_geotiff/data_structures.py
+++ b/yt_geotiff/data_structures.py
@@ -462,6 +462,8 @@ class GeoTiffDataset(Dataset):
 
         p = SlicePlot(wds, 'z', field, data_source=w_data_source,
                       center=center, width=plot_width)
+        # make this an actual pointer so wds doesn't go out of scope
+        p.ds = wds
         return p
 
     @classmethod


### PR DESCRIPTION
I had the y coords of the rasterio window upside down. Following @arevill2's example, we now use the `from_bounds` command to give the physical coordinates of the rasterio window (instead of pixel values). This seems more robust since we rely on rasterio to get it right.

I also fixed an intermittent issue I saw with the window dataset being garbage collected before it could be plotted.