### PR TITLE
add save_as_geotiff function

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,13 +158,13 @@ jobs:
 
       - restore_cache:
           name: "Restore test data cache."
-          key: test-data-v2
+          key: test-data-2021-05-05
 
       - download-test-data
 
       - save_cache:
           name: "Save test data cache."
-          key: test-data-v2
+          key: test-data-2021-05-05
           paths:
             - ~/test_data
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,13 +158,13 @@ jobs:
 
       - restore_cache:
           name: "Restore test data cache."
-          key: test-data-2021-05-05
+          key: test-data-2021-05-05_2
 
       - download-test-data
 
       - save_cache:
           name: "Save test data cache."
-          key: test-data-2021-05-05
+          key: test-data-2021-05-05_2
           paths:
             - ~/test_data
 

--- a/README.md
+++ b/README.md
@@ -219,3 +219,46 @@ Example plot script of a derivable fields:
 >>> p.set_cmap(('band_ratios', 'S2_NDVI'), 'RdYlGn')
 >>> p.show()
 ```
+
+### Saving to a new GeoTiff file
+
+The `save_as_geotiff` function allows one to output multiple fields
+into a single multi-band GeoTiff file. This can be done for either the
+entire image or for a subset represented by geometric data container.
+
+```
+>>> import glob
+>>> import yt
+>>> from yt.extensions.geotiff import save_as_geotiff
+>>>
+>>> fns = glob.glob("*.jp2") + glob.glob("*.TIF")
+>>> ds = yt.load(*fns)
+>>> ds_fn, field_map = save_as_geotiff(ds, "my_data.tif")
+>>> ds_new = yt.load(ds_fn, field_map=field_map)
+```
+
+A supplementary yaml file containing a map between band numbers and
+field names will also be written.
+
+By default, all available on-disk fields will be saved, but a list,
+including derived fields can provided. As well, a data container can
+be provided for which data will only be saved for the rectangular
+bounding box enclosing the container.
+
+```
+>>> import glob
+>>> import yt
+>>> from yt.extensions.geotiff import save_as_geotiff
+>>>
+>>> fns = glob.glob("*.jp2") + glob.glob("*.TIF")
+>>> ds = yt.load(*fns)
+>>> circle = ds.circle(ds.domain_center, (10, 'km'))
+>>> fields = [("bands", "LS_B1"),
+...           ("bands", "S2_B06"),
+...           ("band_ratios", "S2_NDWI"),
+...           ("variables", "LS_temperature")]
+>>> ds_fn, field_map = save_as_geotiff(
+...        ds, "my_data.tiff",
+...        fields=fields, data_source=circle)
+>>> ds_new = yt.load(ds_fn, field_map=field_map)
+```

--- a/tests/test_save_as_geotiff.py
+++ b/tests/test_save_as_geotiff.py
@@ -15,23 +15,23 @@ S2_dir = "M2_Sentinel-2_test_data"
 LS_dir = "Landsat-8_sample_L2"
 
 class GeoTiffSaveTest(TempDirTest):
-    # @requires_file(os.path.join(S2_dir, "T36MVE_20210315T075701_B01.jp2"))
-    # @requires_file(os.path.join(LS_dir, "LC08_L2SP_171060_20210227_20210304_02_T1_SR_B1.TIF"))
-    # def test_save_default(self):
-    #     fns = glob.glob(os.path.join(test_data_dir, S2_dir, "*.jp2")) + \
-    #       glob.glob(os.path.join(test_data_dir, LS_dir, "*.TIF"))
+    @requires_file(os.path.join(S2_dir, "T36MVE_20210315T075701_B01.jp2"))
+    @requires_file(os.path.join(LS_dir, "LC08_L2SP_171060_20210227_20210304_02_T1_SR_B1.TIF"))
+    def test_save_default(self):
+        fns = glob.glob(os.path.join(test_data_dir, S2_dir, "*.jp2")) + \
+          glob.glob(os.path.join(test_data_dir, LS_dir, "*.TIF"))
 
-    #     ds = yt.load(*fns)
+        ds = yt.load(*fns)
 
-    #     ds_fn, fm_fn = save_as_geotiff(ds, "my_data.tif")
-    #     ds_new = yt.load(ds_fn, field_map=fm_fn)
+        ds_fn, fm_fn = save_as_geotiff(ds, "my_data.tif")
+        ds_new = yt.load(ds_fn, field_map=fm_fn)
 
-    #     for field in ds.field_list:
-    #         ad = ds.all_data()
-    #         ad_new = ds_new.all_data()
-    #         assert_array_equal(
-    #             ad[field], ad_new[field],
-    #             err_msg=f"Saved data mismatch for field {field}.")
+        for field in ds.field_list:
+            ad = ds.all_data()
+            ad_new = ds_new.all_data()
+            assert_array_equal(
+                ad[field], ad_new[field],
+                err_msg=f"Saved data mismatch for field {field}.")
 
     @requires_file(os.path.join(S2_dir, "T36MVE_20210315T075701_B01.jp2"))
     @requires_file(os.path.join(LS_dir, "LC08_L2SP_171060_20210227_20210304_02_T1_SR_B1.TIF"))

--- a/tests/test_save_as_geotiff.py
+++ b/tests/test_save_as_geotiff.py
@@ -1,0 +1,65 @@
+import glob
+from numpy.testing import assert_array_equal
+import os
+
+import yt
+from yt.config import ytcfg
+from yt.extensions.geotiff import save_as_geotiff
+
+from yt_geotiff.testing import \
+    requires_file, \
+    TempDirTest
+
+test_data_dir = ytcfg.get("yt", "test_data_dir")
+S2_dir = "M2_Sentinel-2_test_data"
+LS_dir = "Landsat-8_sample_L2"
+
+class GeoTiffSaveTest(TempDirTest):
+    # @requires_file(os.path.join(S2_dir, "T36MVE_20210315T075701_B01.jp2"))
+    # @requires_file(os.path.join(LS_dir, "LC08_L2SP_171060_20210227_20210304_02_T1_SR_B1.TIF"))
+    # def test_save_default(self):
+    #     fns = glob.glob(os.path.join(test_data_dir, S2_dir, "*.jp2")) + \
+    #       glob.glob(os.path.join(test_data_dir, LS_dir, "*.TIF"))
+
+    #     ds = yt.load(*fns)
+
+    #     ds_fn, fm_fn = save_as_geotiff(ds, "my_data.tif")
+    #     ds_new = yt.load(ds_fn, field_map=fm_fn)
+
+    #     for field in ds.field_list:
+    #         ad = ds.all_data()
+    #         ad_new = ds_new.all_data()
+    #         assert_array_equal(
+    #             ad[field], ad_new[field],
+    #             err_msg=f"Saved data mismatch for field {field}.")
+
+    @requires_file(os.path.join(S2_dir, "T36MVE_20210315T075701_B01.jp2"))
+    @requires_file(os.path.join(LS_dir, "LC08_L2SP_171060_20210227_20210304_02_T1_SR_B1.TIF"))
+    def test_save_sphere(self):
+        fns = glob.glob(os.path.join(test_data_dir, S2_dir, "*.jp2")) + \
+          glob.glob(os.path.join(test_data_dir, LS_dir, "*.TIF"))
+
+        ds = yt.load(*fns)
+
+        circle = ds.circle(ds.domain_center, (10, 'km'))
+        fields = [("bands", "LS_B1"),
+                  ("bands", "S2_B06"),
+                  ("band_ratios", "S2_NDWI"),
+                  ("variables", "LS_temperature")]
+        ds_fn, fm_fn = save_as_geotiff(
+            ds, "my_data.tiff",
+            fields=fields, data_source=circle)
+        ds_new = yt.load(ds_fn, field_map=fm_fn)
+
+        left_edge, right_edge = circle.get_bbox()
+        dle = ds.domain_left_edge.to("code_length")
+        dre = ds.domain_right_edge.to("code_length")
+        left_edge.clip(dle, dre, out=left_edge)
+        right_edge.clip(dle, dre, out=right_edge)
+        bbox = ds.box(left_edge, right_edge)
+
+        for field in fields:
+            ad_new = ds_new.all_data()
+            assert_array_equal(
+                bbox[field], ad_new[field],
+                err_msg=f"Saved data mismatch for field {field}.")

--- a/yt_geotiff/__init__.py
+++ b/yt_geotiff/__init__.py
@@ -7,4 +7,6 @@ from .io import \
 from .fields import \
     GeoTiffFieldInfo
 
+from yt_geotiff.utilities import save_as_geotiff
+
 __version__ = '1.0.dev0'

--- a/yt_geotiff/__init__.py
+++ b/yt_geotiff/__init__.py
@@ -1,12 +1,5 @@
-from .data_structures import \
-    GeoTiffDataset
-
-from .io import \
-    IOHandlerGeoTiff
-
-from .fields import \
-    GeoTiffFieldInfo
-
+from yt_geotiff.data_structures import GeoTiffDataset
+from yt_geotiff.io import IOHandlerGeoTiff
 from yt_geotiff.utilities import save_as_geotiff
 
 __version__ = '1.0.dev0'

--- a/yt_geotiff/data_structures.py
+++ b/yt_geotiff/data_structures.py
@@ -29,7 +29,6 @@ from .fields import \
     JPEG2000FieldInfo
 from .utilities import \
     left_aligned_coord_cal, \
-    save_dataset_as_geotiff, \
     parse_awslandsat_metafile, \
     validate_coord_array, \
     validate_quantity, \
@@ -387,10 +386,6 @@ class GeoTiffDataset(Dataset):
             self.unit_registry.add("pixels", res[0], dimensions.length)
         else:
             mylog.warn("x and y pixels have different sizes.")
-
-    def save_as(self, filename):
-        # TODO: generalize this to save any dataset type as GeoTiff.
-        return save_dataset_as_geotiff(self, filename)
 
     def __repr__(self):
         fn = self.basename

--- a/yt_geotiff/data_structures.py
+++ b/yt_geotiff/data_structures.py
@@ -26,7 +26,7 @@ from yt.utilities.parallel_tools.parallel_analysis_interface import \
 from yt.visualization.api import SlicePlot
 
 from .fields import \
-    JPEG2000FieldInfo
+    GeoRasterFieldInfo
 from .utilities import \
     left_aligned_coord_cal, \
     parse_awslandsat_metafile, \
@@ -306,7 +306,7 @@ class JPEG2000Hierarchy(GeoTiffHierarchy):
 class GeoTiffDataset(Dataset):
     """Dataset for saved covering grids, arbitrary grids, and FRBs."""
     _index_class = GeoTiffHierarchy
-    _field_info_class = JPEG2000FieldInfo
+    _field_info_class = GeoRasterFieldInfo
     _dataset_type = 'geotiff'
     _valid_extensions = ('.tif', '.tiff')
     _driver_type = "GTiff"
@@ -635,7 +635,7 @@ class GeoTiffDataset(Dataset):
 
 class JPEG2000Dataset(GeoTiffDataset):
     _index_class = JPEG2000Hierarchy
-    _field_info_class = JPEG2000FieldInfo
+    _field_info_class = GeoRasterFieldInfo
     _valid_extensions = ('.jp2',)
     _driver_type = "JP2OpenJPEG"
     _dataset_type = "JPEG2000"
@@ -644,7 +644,7 @@ class RasterioGroupDataset(GeoTiffDataset):
     _dataset_type = "RasterioGroup"
     _valid_extensions = ('.tif','.tiff','.jp2')
     _index_class = RasterioGroupHierarchy
-    _field_info_class = JPEG2000FieldInfo
+    _field_info_class = GeoRasterFieldInfo
 
 
     # list of all filenames in directory

--- a/yt_geotiff/fields.py
+++ b/yt_geotiff/fields.py
@@ -18,23 +18,7 @@ _landsat_fields = {
     "TIRS_1": "LS_B10"
 }
 
-
-class GeoTiffFieldInfo(FieldInfoContainer):
-    known_other_fields = ()
-    known_particle_fields = ()
-
-    def __init__(self, ds, field_list):
-        super().__init__(ds, field_list)
-
-        if self.ds.field_map is not None:
-            with open(self.ds.field_map, 'r') as f:
-                fmap = yaml.load(f, Loader=yaml.FullLoader)
-
-            for dfield, afield in fmap['field_map'].items():
-                self.alias((fmap['field_type'], afield), ('bands', dfield))
-
-
-class JPEG2000FieldInfo(FieldInfoContainer): # Now also used in RasterioGroupDataset(GeoTiffDataset)
+class GeoRasterFieldInfo(FieldInfoContainer):
     known_other_fields = ()
     known_particle_fields = ()
 
@@ -44,6 +28,14 @@ class JPEG2000FieldInfo(FieldInfoContainer): # Now also used in RasterioGroupDat
         self._create_sentinel2_aliases()
         self._create_landsat_aliases()
         self._setup_geo_fields()
+
+        if self.ds.field_map is not None:
+            with open(self.ds.field_map, 'r') as f:
+                fmap = yaml.load(f, Loader=yaml.FullLoader)
+
+            for dfield, afield in fmap.items():
+                self.alias((afield['field_type'], afield['field_name']),
+                           ('bands', dfield))
 
     def _create_band_aliases(self):
         """

--- a/yt_geotiff/testing.py
+++ b/yt_geotiff/testing.py
@@ -6,6 +6,10 @@ Testing functions.
 """
 
 import os
+import shutil
+import tempfile
+from unittest import \
+    TestCase
 from yt.config import ytcfg
 
 def check_path(filename):
@@ -47,3 +51,18 @@ def requires_file(filename):
     except IOError:
         return ffalse
     return ftrue
+
+class TempDirTest(TestCase):
+    """
+    A test class that runs in a temporary directory and
+    removes it afterward.
+    """
+
+    def setUp(self):
+        self.curdir = os.getcwd()
+        self.tmpdir = tempfile.mkdtemp()
+        os.chdir(self.tmpdir)
+
+    def tearDown(self):
+        os.chdir(self.curdir)
+        shutil.rmtree(self.tmpdir)

--- a/yt_geotiff/utilities.py
+++ b/yt_geotiff/utilities.py
@@ -131,6 +131,11 @@ def save_as_geotiff(ds, filename, fields=None, data_source=None):
     >>>
     >>> ds_new = yt.load(new_fn, field_map=new_fmap)
 
+    >>> circle = ds.circle(ds.domain_center, (10, 'km'))
+    >>> fields = [("bands", "LS_B1"),
+    ...           ("bands", "S2_B06"),
+    ...           ("band_ratios", "S2_NDWI")]
+    >>> save_as_geotiff(ds, "my_data.tiff", fields=fields, data_source=circle)
     """
 
     if fields is None:

--- a/yt_geotiff/utilities.py
+++ b/yt_geotiff/utilities.py
@@ -177,7 +177,13 @@ def save_as_geotiff(ds, filename, fields=None, data_source=None):
             band = i + 1
             ytLogger.info(f"Saving {field} to band {band}/{len(fields)}.")
             field_info[str(band)] = {"field_type": field[0], "field_name": field[1]}
-            dst.write(np.reshape(my_data_source[field].d, (width, height)), band)
+            for attr in ["take_log", "units"]:
+                field_info[str(band)][attr] = getattr(ds.field_info[field], attr)
+            data = np.reshape(my_data_source[field].d, (width, height), order="C")
+            if ds._flip_axes:
+                data = np.flip(data, axis=ds._flip_axes)
+            data = data.T
+            dst.write(data, band)
 
     yfn = f"{filename[:filename.rfind('.')]}_fields.yaml"
     with open(yfn, mode="w") as f:


### PR DESCRIPTION
This adds the `save_as_geotiff` function to selected fields from a data container to a multiband GeoTiff file. With this, one can do:
```
fns = glob.glob(os.path.join("M2_Sentinel-2_test_data", "*.jp2")) + \
  glob.glob(os.path.join("Landsat-8_sample_L2", "*.TIF"))

ds = yt.load(*fns)

circle = ds.circle(ds.domain_center, (10, 'km'))
fields = [("bands", "LS_B1"),
          ("bands", "S2_B06"),
          ("band_ratios", "S2_NDWI")]
ds_fn, fm_fn = save_as_geotiff(ds, "my_data.tiff", fields=fields, data_source=circle)

ds2 = yt.load(ds_fn, field_map=fm_fn)
```

To do this, I've slightly changed the format of the field map yaml file. I've also added some new tests.