### PR TITLE
Support loading multiple images with same bands

### DIFF
--- a/tests/test_circle.py
+++ b/tests/test_circle.py
@@ -33,7 +33,7 @@ def test_circle_lu():
 
     # check number of points in sufficiently large circle
     n1 = a1 / ds.resolution.prod()
-    n2 = circle[('bands', '200km_2p5m_N38E34_1')].size
+    n2 = circle[('200km_2p5m_N38E34', 'band_1')].size
     assert_almost_equal(n1/n2, 1, decimal=5)
 
 @requires_file(landsat)
@@ -50,10 +50,10 @@ def test_circle_ls():
 
     # check number of points in sufficiently large circle
     n1 = np.pi * circle.radius**2 / ds.resolution.prod()
-    n2 = circle[('bands', 'LS_B1')].size
+    n2 = circle[('LC08_L2SP_171060_20210227_20210304_02_T1', 'L8_B1')].size
     assert_almost_equal(n1/n2, 1, decimal=5)
 
-    n3 = circle[('bands', 'S2_B01')].size
+    n3 = circle[('T36MVE_20210315T075701', 'S2_B01')].size
     assert_almost_equal(n1/n3, 1, decimal=5)
 
     assert_equal(n2, n3)
@@ -72,12 +72,12 @@ def test_circle_s2():
 
     # check number of points in sufficiently large circle
     n1 = np.pi * circle.radius**2 / ds.resolution.prod()
-    n2 = circle[('bands', 'LS_B1')].size
+    n2 = circle[('LC08_L2SP_171060_20210227_20210304_02_T1', 'L8_B1')].size
 
     # lower decimal precision since this sphere is smaller
     assert_almost_equal(n1/n2, 1, decimal=3)
 
-    n3 = circle[('bands', 'S2_B01')].size
+    n3 = circle[('T36MVE_20210315T075701', 'S2_B01')].size
     assert_almost_equal(n1/n3, 1, decimal=3)
 
     assert_equal(n2, n3)

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -21,7 +21,7 @@ def test_grid():
     fns = s2_fns + landsat_fns
     ds = yt.load(*fns)
 
-    n1 = ds.data[('bands', 'LS_B1')].shape
-    n2 = ds.data[('bands', 'S2_B01')].shape
+    n1 = ds.data[('LC08_L2SP_171060_20210227_20210304_02_T1', 'L8_B1')].shape
+    n2 = ds.data[('T36MVE_20210315T075701', 'S2_B01')].shape
     assert_equal(n1, n2)
     assert_equal(n1, tuple(ds.data.ActiveDimensions))

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -23,10 +23,10 @@ class GeoRasterPlotTest(TempDirTest):
 
         ds = yt.load(*fns)
 
-        fields = [("bands", "LS_B1_30m"),
-                  ("bands", "S2_B06_20m"),
-                  ("band_ratios", "S2_NDWI"),
-                  ("variables", "LS_temperature")]
+        fields = [("LC08_L2SP_171060_20210227_20210304_02_T1", "L8_B1_30m"),
+                  ("T36MVE_20210315T075701", "S2_B06_20m"),
+                  ("T36MVE_20210315T075701", "NDWI"),
+                  ("LC08_L2SP_171060_20210227_20210304_02_T1", "LS_temperature")]
 
         for field in fields:
             p = ds.plot(field)
@@ -40,10 +40,10 @@ class GeoRasterPlotTest(TempDirTest):
 
         ds = yt.load(*fns)
 
-        fields = [("bands", "LS_B1_30m"),
-                  ("bands", "S2_B06_20m"),
-                  ("band_ratios", "S2_NDWI"),
-                  ("variables", "LS_temperature")]
+        fields = [("LC08_L2SP_171060_20210227_20210304_02_T1", "L8_B1_30m"),
+                  ("T36MVE_20210315T075701", "S2_B06_20m"),
+                  ("T36MVE_20210315T075701", "NDWI"),
+                  ("LC08_L2SP_171060_20210227_20210304_02_T1", "LS_temperature")]
 
         circle = ds.circle(ds.domain_center, 0.25 * ds.domain_width[:2].min())
         for field in fields:
@@ -59,8 +59,8 @@ class GeoRasterPlotTest(TempDirTest):
 
         ds = yt.load(*fns)
 
-        fields = [("bands", "LS_B1_30m"),
-                  ("variables", "LS_temperature")]
+        fields = [("LC08_L2SP_171060_20210227_20210304_02_T1", "L8_B1_30m"),
+                  ("LC08_L2SP_171060_20210227_20210304_02_T1", "LS_temperature")]
 
         polygon = ds.polygon(os.path.join(test_data_dir, poly_multi))
         for field in fields:

--- a/tests/test_polygon.py
+++ b/tests/test_polygon.py
@@ -25,8 +25,8 @@ def test_polygon_single():
     ds = yt.load(*fns)
 
     polygon = ds.polygon(os.path.join(test_data_dir, poly_single))
-    assert_equal(polygon['LS_B10'].size, 368007)
-    assert_equal(polygon['S2_B10'].size, 368007)
+    assert_equal(polygon["LC08_L2SP_171060_20210227_20210304_02_T1", "L8_B10"].size, 368007)
+    assert_equal(polygon["T36MVE_20210315T075701", "S2_B10"].size, 368007)
 
 @requires_file(landsat)
 @requires_file(s2)
@@ -36,5 +36,5 @@ def test_polygon_multi():
     ds = yt.load(*fns)
 
     polygon = ds.polygon(os.path.join(test_data_dir, poly_multi))
-    assert_equal(polygon['LS_B10'].size, 551624)
-    assert_equal(polygon['S2_B10'].size, 551624)
+    assert_equal(polygon["LC08_L2SP_171060_20210227_20210304_02_T1", "L8_B10"].size, 551624)
+    assert_equal(polygon["T36MVE_20210315T075701", "S2_B10"].size, 551624)

--- a/tests/test_rectangle.py
+++ b/tests/test_rectangle.py
@@ -36,10 +36,10 @@ def test_rectangle_ls():
     assert_almost_equal(a1/a2, 1, decimal=3)
 
     n1 = a1 / ds.resolution.prod()
-    n2 = rectangle[('bands', 'LS_B1')].size
+    n2 = rectangle[('LC08_L2SP_171060_20210227_20210304_02_T1', 'L8_B1')].size
     assert_almost_equal(n1/n2, 1, decimal=3)
 
-    n3 = rectangle[('bands', 'S2_B01')].size
+    n3 = rectangle[('T36MVE_20210315T075701', 'S2_B01')].size
     assert_almost_equal(n1/n3, 1, decimal=3)
 
     assert_equal(n2, n3)
@@ -65,10 +65,10 @@ def test_rectangle_s2():
     assert_almost_equal(a1/a2, 1, decimal=2)
 
     n1 = a1 / ds.resolution.prod()
-    n2 = rectangle[('bands', 'LS_B1')].size
+    n2 = rectangle[('LC08_L2SP_171060_20210227_20210304_02_T1', 'L8_B1')].size
     assert_almost_equal(n1/n2, 1, decimal=2)
 
-    n3 = rectangle[('bands', 'S2_B01')].size
+    n3 = rectangle[('T36MVE_20210315T075701', 'S2_B01')].size
     assert_almost_equal(n1/n3, 1, decimal=2)
 
     assert_equal(n2, n3)
@@ -92,10 +92,10 @@ def test_rectangle_overlaps_edge():
     assert_almost_equal(a1/a2, 1, decimal=3)
 
     n1 = a1 / ds.resolution.prod()
-    n2 = rectangle[('bands', 'LS_B1')].size
+    n2 = rectangle[('LC08_L2SP_171060_20210227_20210304_02_T1', 'L8_B1')].size
     assert_almost_equal(n1/n2, 1, decimal=3)
 
-    n3 = rectangle[('bands', 'S2_B01')].size
+    n3 = rectangle[('T36MVE_20210315T075701', 'S2_B01')].size
     assert_almost_equal(n1/n3, 1, decimal=3)
 
     assert_equal(n2, n3)

--- a/tests/test_save_as_geotiff.py
+++ b/tests/test_save_as_geotiff.py
@@ -24,10 +24,10 @@ class GeoRasterSaveTest(TempDirTest):
 
         ds = yt.load(*fns)
 
-        fields = [("bands", "LS_B1_30m"),
-                  ("bands", "S2_B06_20m"),
-                  ("band_ratios", "S2_NDWI"),
-                  ("variables", "LS_temperature")]
+        fields = [("LC08_L2SP_171060_20210227_20210304_02_T1", "L8_B1"),
+                  ("T36MVE_20210315T075701", "S2_B06"),
+                  ("T36MVE_20210315T075701", "NDWI"),
+                  ("LC08_L2SP_171060_20210227_20210304_02_T1", "LS_temperature")]
 
         ds_fn, fm_fn = save_as_geotiff(
             ds, "my_data.tiff", fields=fields)
@@ -49,10 +49,10 @@ class GeoRasterSaveTest(TempDirTest):
         ds = yt.load(*fns)
 
         circle = ds.circle(ds.domain_center, (10, 'km'))
-        fields = [("bands", "LS_B1_30m"),
-                  ("bands", "S2_B06_20m"),
-                  ("band_ratios", "S2_NDWI"),
-                  ("variables", "LS_temperature")]
+        fields = [("LC08_L2SP_171060_20210227_20210304_02_T1", "L8_B1"),
+                  ("T36MVE_20210315T075701", "S2_B06"),
+                  ("T36MVE_20210315T075701", "NDWI"),
+                  ("LC08_L2SP_171060_20210227_20210304_02_T1", "LS_temperature")]
         ds_fn, fm_fn = save_as_geotiff(
             ds, "my_data.tiff",
             fields=fields, data_source=circle)
@@ -75,9 +75,9 @@ class GeoRasterSaveTest(TempDirTest):
         ds = yt.load(*fns)
 
         polygon = ds.polygon(os.path.join(test_data_dir, poly_multi))
-        fields = [("bands", "LS_B1_30m"),
-                  ("bands", "S2_B06_20m"),
-                  ("variables", "LS_temperature")]
+        fields = [("LC08_L2SP_171060_20210227_20210304_02_T1", "L8_B1"),
+                  ("T36MVE_20210315T075701", "S2_B06"),
+                  ("LC08_L2SP_171060_20210227_20210304_02_T1", "LS_temperature")]
         ds_fn, fm_fn = save_as_geotiff(
             ds, "my_data.tiff",
             fields=fields, data_source=polygon)

--- a/yt_geotiff/data_structures.py
+++ b/yt_geotiff/data_structures.py
@@ -39,8 +39,6 @@ from .utilities import \
     validate_coord_array, \
     validate_quantity, \
     log_level
-# from .utilities import s1_data_manager
-
 
 class GeoRasterWindowGrid(YTGrid):
     def __init__(self, gridobj, left_edge, right_edge):
@@ -253,16 +251,13 @@ class GeoRasterHierarchy(YTGridHierarchy):
         self.field_list = []
         self.ds.field_units = self.ds.field_units or {}
 
-        # Number of bands in image dataset
-        self.ds._field_band_map = {}
-
-        geo_manager = GeoManager(self)
-
-        for fn in self.ds.filename_list:
-            geo_manager.process(fn)
+        # The geo manager identifies files with various imagery/satellite
+        # naming conventions.
+        self.geo_manager = gm = GeoManager(self)
+        gm.process_files(self.ds.filename_list)
 
         ftypes = set(self.ds.fluid_types)
-        new_ftypes = set(geo_manager.ftypes)
+        new_ftypes = set(gm.ftypes)
         self.ds.fluid_types = tuple(ftypes.union(new_ftypes))
 
 

--- a/yt_geotiff/data_structures.py
+++ b/yt_geotiff/data_structures.py
@@ -268,8 +268,8 @@ class GeoRasterDataset(Dataset):
     _valid_extensions = ('.tif','.tiff','.jp2')
     _driver_types = ("GTiff", "JP2OpenJPEG")
     geometry = "cartesian"
-    default_fluid_type = "bands"
-    fluid_types = ("bands", "index")
+    default_fluid_type = None
+    fluid_types = ()
     _periodicity = np.zeros(3, dtype=bool)
     cosmological_simulation = False
     refine_by = 2

--- a/yt_geotiff/data_structures.py
+++ b/yt_geotiff/data_structures.py
@@ -247,7 +247,6 @@ class GeoRasterHierarchy(YTGridHierarchy):
         self.num_grids = 1
 
     def _detect_output_fields(self):
-        # Follow example for GeoRasterHierarchy to populate the field list.
         self.field_list = []
         self.ds.field_units = self.ds.field_units or {}
 

--- a/yt_geotiff/data_structures.py
+++ b/yt_geotiff/data_structures.py
@@ -256,10 +256,10 @@ class GeoRasterHierarchy(YTGridHierarchy):
         # Number of bands in image dataset
         self.ds._field_band_map = {}
 
-        geo_manager = GeoManager()
+        geo_manager = GeoManager(self)
 
         for fn in self.ds.filename_list:
-            geo_manager.process(self, fn)
+            geo_manager.process(fn)
 
         ftypes = set(self.ds.fluid_types)
         new_ftypes = set(geo_manager.ftypes)

--- a/yt_geotiff/data_structures.py
+++ b/yt_geotiff/data_structures.py
@@ -252,7 +252,8 @@ class GeoRasterHierarchy(YTGridHierarchy):
 
         # The geo manager identifies files with various imagery/satellite
         # naming conventions.
-        self.geo_manager = gm = GeoManager(self)
+        self.geo_manager = gm = \
+          GeoManager(self, field_map=self.ds.field_map)
         gm.process_files(self.ds.filename_list)
 
         ftypes = set(self.ds.fluid_types)

--- a/yt_geotiff/data_structures.py
+++ b/yt_geotiff/data_structures.py
@@ -259,7 +259,7 @@ class GeoRasterHierarchy(YTGridHierarchy):
         geo_manager = GeoManager()
 
         for fn in self.ds.filename_list:
-            geo_manager.identify(self, fn)
+            geo_manager.process(self, fn)
 
         ftypes = set(self.ds.fluid_types)
         new_ftypes = set(geo_manager.ftypes)

--- a/yt_geotiff/data_structures.py
+++ b/yt_geotiff/data_structures.py
@@ -359,6 +359,9 @@ class GeoRasterDataset(Dataset):
                 break
         return fn
 
+    def __str__(self):
+        return self.__repr__()
+
     def _update_transform(self, transform, left_edge, right_edge):
         """
         Create a new rasterio transform given left and right edge coordinates.

--- a/yt_geotiff/data_structures.py
+++ b/yt_geotiff/data_structures.py
@@ -270,7 +270,7 @@ class GeoRasterDataset(Dataset):
     _driver_types = ("GTiff", "JP2OpenJPEG")
     geometry = "cartesian"
     default_fluid_type = None
-    fluid_types = ()
+    fluid_types = ("index",)
     _periodicity = np.zeros(3, dtype=bool)
     cosmological_simulation = False
     refine_by = 2

--- a/yt_geotiff/fields.py
+++ b/yt_geotiff/fields.py
@@ -1,6 +1,5 @@
 from collections import defaultdict
 import re
-import yaml
 
 from yt.fields.field_info_container import \
     FieldInfoContainer
@@ -24,40 +23,9 @@ class GeoRasterFieldInfo(FieldInfoContainer):
 
     def __init__(self, ds, field_list):
         super().__init__(ds, field_list)
-        self._create_field_map_aliases()
         self._create_highres_aliases()
         self._create_satellite_aliases()
         self._setup_geo_fields()
-
-    def _create_field_map_aliases(self):
-        """
-        Read the field map file and create aliases.
-        """
-
-        if self.ds.field_map is None:
-            return
-
-        with open(self.ds.field_map, 'r') as f:
-            field_map = yaml.load(f, Loader=yaml.FullLoader)
-
-        for filename, fmap in field_map.items():
-            for dfield, afield in fmap.items():
-                my_field = f"{filename}_{dfield}"
-                self._add_field_map_band_alias(my_field, afield)
-
-    def _add_field_map_band_alias(self, band, afield):
-        """
-        Add an alias entry from the field map file.
-        """
-        units = afield.get("units", "")
-        def my_field(field, data):
-            return data.ds.arr(data["bands", band], units)
-        self.add_field(
-            (afield['field_type'], afield['field_name']),
-            function=my_field, sampling_type="local",
-            force_override=True,
-            take_log=afield.get("take_log", True),
-            units=units)
 
     def _create_highres_aliases(self):
         """

--- a/yt_geotiff/fields.py
+++ b/yt_geotiff/fields.py
@@ -67,6 +67,7 @@ class GeoRasterFieldInfo(FieldInfoContainer):
 
             # Normalised difference water index (NDWI)
             def _ndwi(field, data):
+                ftype = field.name[0]
                 green = data[ftype, "green"]
                 nir = data[ftype, "nir"]
                 return (green - nir) / (green + nir)
@@ -80,11 +81,12 @@ class GeoRasterFieldInfo(FieldInfoContainer):
 
             # Maximum chlorophyll index (MCI)
             def _mci(field, data):
-                visible_red = data[ftype, "red"]
-                red_edge_1 = data[ftype, "red_edge1"]
-                red_edge_2 = data[ftype, "red_edge2"]
-                return (red_edge_1  - visible_red) - \
-                  0.53 * (red_edge_2 - visible_red)
+                ftype = field.name[0]
+                red = data[ftype, "red"]
+                red_edge_1 = data[ftype, "red_edge_1"]
+                red_edge_2 = data[ftype, "red_edge_2"]
+                return (red_edge_1  - red) - \
+                  0.53 * (red_edge_2 - red)
 
             self.add_field(
                 (ftype, "MCI"),
@@ -95,9 +97,10 @@ class GeoRasterFieldInfo(FieldInfoContainer):
 
             # Colored Dissolved Organic Matter (CDOM)
             def _cdom(field, data):
-                visible_blue = data[ftype, "blue"]
-                visible_green = data[ftype, "green"]
-                return 8 * (visible_green / visible_blue)**(-1.4)
+                ftype = field.name[0]
+                blue = data[ftype, "blue"]
+                green = data[ftype, "green"]
+                return 8 * (green / blue)**(-1.4)
 
             self.add_field(
                 (ftype, "CDOM"),
@@ -108,11 +111,12 @@ class GeoRasterFieldInfo(FieldInfoContainer):
 
             # Enhanced Vegetation Index (EVI)
             def _evi(field, data):
-                visible_blue = data[ftype, "blue"]
-                visible_red = data[ftype, "red"]
+                ftype = field.name[0]
+                blue = data[ftype, "blue"]
+                red = data[ftype, "red"]
                 nir = data[ftype, "nir"]
-                return 2.5 * (nir - visible_red) / \
-                  ((nir + 6.0 * visible_red - 7.5 * visible_blue) + 1.0)
+                return 2.5 * (nir - red) / \
+                  ((nir + 6.0 * red - 7.5 * blue) + 1.0)
 
             self.add_field(
                 (ftype, "EVI"),
@@ -123,9 +127,10 @@ class GeoRasterFieldInfo(FieldInfoContainer):
 
             # Normalised Difference Vegetation Index (NDVI)
             def _ndvi(field, data):
-                visible_red = data[ftype, "red"]
+                ftype = field.name[0]
+                red = data[ftype, "red"]
                 nir = data[ftype, "nir"]
-                return (nir - visible_red) / (nir + visible_red)
+                return (nir - red) / (nir + red)
 
             self.add_field(
                 (ftype, "NDVI"),
@@ -136,7 +141,8 @@ class GeoRasterFieldInfo(FieldInfoContainer):
 
             # Landsat Temperature
             def _LS_temperature(field, data):
-                thermal_infrared_1 = data[ftype, "tirs1"]
+                ftype = field.name[0]
+                thermal_infrared_1 = data[ftype, "tirs_1"]
                 return data.ds.arr((thermal_infrared_1 * 0.00341802 + 149), 'K')
 
             self.add_field(

--- a/yt_geotiff/fields.py
+++ b/yt_geotiff/fields.py
@@ -4,19 +4,6 @@ import re
 from yt.fields.field_info_container import \
     FieldInfoContainer
 
-_sentinel2_fields = {
-    "blue": "S2_B02",
-    "green": "S2_B03",
-    "red" : "S2_B04",
-    "nir": "S2_B8A",
-    "red_edge_1" : "S2_B05",
-    "red_edge_2" : "S2_B06"
-}
-
-_landsat_fields = {
-    "TIRS_1": "LS_B10"
-}
-
 class GeoRasterFieldInfo(FieldInfoContainer):
     known_other_fields = ()
     known_particle_fields = ()

--- a/yt_geotiff/fields.py
+++ b/yt_geotiff/fields.py
@@ -98,84 +98,6 @@ class GeoRasterFieldInfo(FieldInfoContainer):
         """
         Add geo-sciences derived fields.
         """
-        # Normalised difference water index (NDWI)
-        def _ndwi(field, data):
-            green = data["bands", "green"]
-            nir = data["bands", "nir"]
-            return (green - nir) / (green + nir)
-
-        self.add_field(
-            ("band_ratios", "S2_NDWI"),
-            function=_ndwi,
-            sampling_type="local",
-            take_log=False,
-            units="")
-
-        # Maximum chlorophyll index (MCI)
-        def _mci(field, data):
-            visible_red = data["bands", "red"]
-            red_edge_1 = data["bands", "red_edge_1"]
-            red_edge_2 = data["bands", "red_edge_2"]
-            return (red_edge_1  - visible_red) - 0.53*(red_edge_2 - visible_red)
-
-        self.add_field(
-            ("band_ratios", "S2_MCI"),
-            function=_mci,
-            sampling_type="local",
-            take_log=False,
-            units="")
-
-        # Colored Dissolved Organic Matter (CDOM)
-        def _cdom(field, data):
-            visible_blue = data["bands", "blue"]
-            visible_green = data["bands", "green"]
-            return 8* (visible_green/visible_blue)**(-1.4)
-
-        self.add_field(
-            ("band_ratios", "S2_CDOM"),
-            function=_cdom,
-            sampling_type="local",
-            take_log=False,
-            units="")
-
-        # Enhanced Vegetation Index (EVI)
-        def _evi(field, data):
-            visible_blue = data["bands", "blue"]
-            visible_red = data["bands", "red"]
-            nir = data["bands", "nir"]
-            return 2.5 * (nir - visible_red) / ((nir + 6.0 * visible_red - 7.5 * visible_blue) + 1.0)
-
-        self.add_field(
-            ("band_ratios", "S2_EVI"),
-            function=_evi,
-            sampling_type="local",
-            take_log=False,
-            units="")
-
-        # Normalised Difference Vegetation Index (NDVI)
-        def _ndvi(field, data):
-            visible_red = data["bands", "red"]
-            nir = data["bands", "nir"]
-            return ((nir - visible_red) / (nir + visible_red))
-
-        self.add_field(
-            ("band_ratios", "S2_NDVI"),
-            function=_ndvi,
-            sampling_type="local",
-            take_log=False,
-            units="")
-
-        # Landsat Temperature
-        def _LS_temperature(field, data):
-            thermal_infrared_1 = data["bands", "TIRS_1"]
-            return data.ds.arr((thermal_infrared_1*0.00341802 + 149),'K')
-
-        self.add_field(
-            ("variables", "LS_temperature"),
-            function=_LS_temperature,
-            sampling_type="local",
-            take_log=False,
-            units="K")
 
         # Area coverage of field
         def _area(field, data):
@@ -185,3 +107,86 @@ class GeoRasterFieldInfo(FieldInfoContainer):
         self.add_field(("index", "area"), function=_area,
             sampling_type="local",
             units="km**2")
+
+        for ftype in self.ds.index.geo_manager.ftypes:
+
+            # Normalised difference water index (NDWI)
+            def _ndwi(field, data):
+                green = data[ftype, "green"]
+                nir = data[ftype, "nir"]
+                return (green - nir) / (green + nir)
+
+            self.add_field(
+                (ftype, "NDWI"),
+                function=_ndwi,
+                sampling_type="local",
+                take_log=False,
+                units="")
+
+            # Maximum chlorophyll index (MCI)
+            def _mci(field, data):
+                visible_red = data[ftype, "red"]
+                red_edge_1 = data[ftype, "red_edge1"]
+                red_edge_2 = data[ftype, "red_edge2"]
+                return (red_edge_1  - visible_red) - \
+                  0.53 * (red_edge_2 - visible_red)
+
+            self.add_field(
+                (ftype, "MCI"),
+                function=_mci,
+                sampling_type="local",
+                take_log=False,
+                units="")
+
+            # Colored Dissolved Organic Matter (CDOM)
+            def _cdom(field, data):
+                visible_blue = data[ftype, "blue"]
+                visible_green = data[ftype, "green"]
+                return 8 * (visible_green / visible_blue)**(-1.4)
+
+            self.add_field(
+                (ftype, "CDOM"),
+                function=_cdom,
+                sampling_type="local",
+                take_log=False,
+                units="")
+
+            # Enhanced Vegetation Index (EVI)
+            def _evi(field, data):
+                visible_blue = data[ftype, "blue"]
+                visible_red = data[ftype, "red"]
+                nir = data[ftype, "nir"]
+                return 2.5 * (nir - visible_red) / \
+                  ((nir + 6.0 * visible_red - 7.5 * visible_blue) + 1.0)
+
+            self.add_field(
+                (ftype, "EVI"),
+                function=_evi,
+                sampling_type="local",
+                take_log=False,
+                units="")
+
+            # Normalised Difference Vegetation Index (NDVI)
+            def _ndvi(field, data):
+                visible_red = data[ftype, "red"]
+                nir = data[ftype, "nir"]
+                return (nir - visible_red) / (nir + visible_red)
+
+            self.add_field(
+                (ftype, "NDVI"),
+                function=_ndvi,
+                sampling_type="local",
+                take_log=False,
+                units="")
+
+            # Landsat Temperature
+            def _LS_temperature(field, data):
+                thermal_infrared_1 = data[ftype, "tirs1"]
+                return data.ds.arr((thermal_infrared_1 * 0.00341802 + 149), 'K')
+
+            self.add_field(
+                (ftype, "LS_temperature"),
+                function=_LS_temperature,
+                sampling_type="local",
+                take_log=False,
+                units="degC")

--- a/yt_geotiff/image_types.py
+++ b/yt_geotiff/image_types.py
@@ -86,6 +86,7 @@ class GeoManager:
     def __init__(self, index):
         self.index = index
         self.ftypes = []
+        self.fields = {}
 
     def add_field_type(self, ftype):
         if ftype not in self.ftypes:
@@ -107,12 +108,15 @@ class GeoManager:
                 fname += f"_{i}"
 
             field = (ftype, fname)
+            self.fields[field] = {"filename": fullpath, "band": i}
             self.index.field_list.append(field)
             self.index.ds.field_units[field] = ""
-            self.index.ds._field_band_map.update(
-                {fname: {'filename': fullpath, 'band': i}})
 
-    def process(self, fullpath):
+    def process_files(self, fullpaths):
+        for fn in fullpaths:
+            self.process_file(fn)
+
+    def process_file(self, fullpath):
         _, filename = os.path.split(fullpath)
 
         for imager in self.image_types:

--- a/yt_geotiff/image_types.py
+++ b/yt_geotiff/image_types.py
@@ -1,0 +1,84 @@
+import os
+import rasterio
+import re
+
+class Imager:
+    field_aliases = ()
+
+    def split(self, filename):
+        "Return a prefix and suffix for a filename."
+        return filename.rsplit(".", 1)
+
+    def process(self, filename, resolution):
+        prefix, _ = self.split(filename)
+        return prefix, "band"
+
+class SatImager(Imager):
+    def process(self, filename, resolution):
+        prefix, suffix = self.split(filename)
+        if suffix.lower() != self._suffix:
+            return None
+
+        search = self._regex.search(prefix)
+        if search is None:
+            return None
+
+        groups = [g for g in search.groups() if g is not None]
+        fname = f"{self._field_prefix}_{groups[0]}_{resolution}"
+
+        fsearch = re.search(f"(.+)_{''.join(groups)}", filename)
+        if fsearch is None:
+            return None
+        ftype = fsearch.groups()[0]
+
+        return ftype, fname
+
+class Sentinel2(SatImager):
+    _regex = re.compile(r"_([A-Za-z0-9]+)(_\d+m)?$")
+    _suffix = "jp2"
+    _field_prefix = "S2"
+
+class Landsat8(SatImager):
+    _regex = re.compile(r"^LC.+_([A-Za-z0-9]+)$")
+    _suffix = "tif"
+    _field_prefix = "L8"
+
+
+class GeoManager:
+    def __init__(self):
+        self.ftypes = []
+        self.default_imager = Imager()
+        self.imagers = [Sentinel2(), Landsat8()]
+
+    @property
+    def all_imagers(self):
+        return self.imagers + [self.default_imager]
+
+    def identify(self, index, fullpath):
+        _, filename = os.path.split(fullpath)
+
+        units = "m"
+        with rasterio.open(fullpath, mode="r") as f:
+            resolution = f"{int(f.res[0])}{units}"
+            count = f.count
+
+        for imager in self.all_imagers:
+            res = imager.process(filename, resolution)
+            if res is None:
+                continue
+            ftype, fname = res
+
+            if ftype not in self.ftypes:
+                self.ftypes.append(ftype)
+
+            for i in range(1, count + 1):
+                fieldname = fname
+                if count > 1 or fieldname == "band":
+                    fieldname += f"_{i}"
+
+                field = (ftype, fieldname)
+                index.field_list.append(field)
+                index.ds.field_units[field] = ""
+                index.ds._field_band_map.update(
+                    {fieldname: {'filename': fullpath, 'band': i}})
+            break

--- a/yt_geotiff/image_types.py
+++ b/yt_geotiff/image_types.py
@@ -3,7 +3,7 @@ import rasterio
 import re
 
 class GeoImage:
-    field_aliases = ()
+    _band_aliases = ()
 
     def split(self, filename):
         "Return a prefix and suffix for a filename."
@@ -30,7 +30,7 @@ class SatGeoImage(GeoImage):
         return ftype, fprefix
 
 class Sentinel2(SatGeoImage):
-    _regex = re.compile(r"(\w+)_([A-Za-z0-9]+)(_\d+m)?$")
+    _regex = re.compile(r"([A-Za-z0-9]+_[A-Za-z0-9]+)_([A-Za-z0-9]+)(?:_\d+m)?$")
     _suffix = "jp2"
     _field_prefix = "S2"
     _band_aliases = (
@@ -91,6 +91,15 @@ class GeoManager:
     def add_field_type(self, ftype):
         if ftype not in self.ftypes:
             self.ftypes.append(ftype)
+
+    @property
+    def band_aliases(self):
+        aliases = {}
+        for it in self.image_types:
+            for field, band_aliases in it._band_aliases:
+                fname = f"{it._field_prefix}_{field}"
+                aliases[fname] = band_aliases
+        return aliases
 
     def create_fields(self, fullpath, ftype, fprefix):
         units = "m"

--- a/yt_geotiff/image_types.py
+++ b/yt_geotiff/image_types.py
@@ -33,6 +33,21 @@ class Sentinel2(SatGeoImage):
     _regex = re.compile(r"(\w+)_([A-Za-z0-9]+)(_\d+m)?$")
     _suffix = "jp2"
     _field_prefix = "S2"
+    _band_aliases = (
+        ("B01", ("ultra_blue",)),
+        ("B02", ("blue",)),
+        ("B03", ("green",)),
+        ("B04", ("red",)),
+        ("B05", ("vnir1", "red_edge1")),
+        ("B06", ("vnir2", "red_edge2")),
+        ("B07", ("vnir3",)),
+        ("B08", ("vnir4",)),
+        ("B8A", ("vnir5", "nir")),
+        ("B09", ("swir1",)),
+        ("B10", ("swir2",)),
+        ("B11", ("swir3",)),
+        ("B12", ("swir4",)),
+    )
 
 class Landsat8(SatGeoImage):
     """
@@ -51,6 +66,19 @@ class Landsat8(SatGeoImage):
     _regex = re.compile(r"(^L[COTEM]08_L\w{3}_\d{6}_\d{8}_\d{8}_\d{2}_\w{2})\w+_([A-Za-z0-9]+)$")
     _suffix = "tif"
     _field_prefix = "L8"
+    _band_aliases = (
+        ("B1", ("visible1",)),
+        ("B2", ("visible2",)),
+        ("B3", ("visible3",)),
+        ("B4", ("red",)),
+        ("B5", ("nir",)),
+        ("B6", ("swir1",)),
+        ("B7", ("swir2",)),
+        ("B8", ("pan",)),
+        ("B9", ("cirrus",)),
+        ("B10", ("tirs1",)),
+        ("B11", ("tirs2",)),
+    )
 
 class GeoManager:
     image_types = (Sentinel2(), Landsat8(), GeoImage())

--- a/yt_geotiff/image_types.py
+++ b/yt_geotiff/image_types.py
@@ -39,15 +39,15 @@ class Sentinel2(SatGeoImage):
         ("B02", ("blue",)),
         ("B03", ("green",)),
         ("B04", ("red",)),
-        ("B05", ("vnir1", "red_edge1")),
-        ("B06", ("vnir2", "red_edge2")),
-        ("B07", ("vnir3",)),
-        ("B08", ("vnir4",)),
-        ("B8A", ("vnir5", "nir")),
-        ("B09", ("swir1",)),
-        ("B10", ("swir2",)),
-        ("B11", ("swir3",)),
-        ("B12", ("swir4",)),
+        ("B05", ("vnir_1", "red_edge_1")),
+        ("B06", ("vnir_2", "red_edge_2")),
+        ("B07", ("vnir_3",)),
+        ("B08", ("vnir_4",)),
+        ("B8A", ("vnir_5", "nir")),
+        ("B09", ("swir_1",)),
+        ("B10", ("swir_2",)),
+        ("B11", ("swir_3",)),
+        ("B12", ("swir_4",)),
     )
 
 class Landsat8(SatGeoImage):
@@ -68,17 +68,17 @@ class Landsat8(SatGeoImage):
     _suffix = "tif"
     _field_prefix = "L8"
     _band_aliases = (
-        ("B1", ("visible1",)),
-        ("B2", ("visible2",)),
-        ("B3", ("visible3",)),
+        ("B1", ("visible_1",)),
+        ("B2", ("visible_2",)),
+        ("B3", ("visible_3",)),
         ("B4", ("red",)),
         ("B5", ("nir",)),
-        ("B6", ("swir1",)),
-        ("B7", ("swir2",)),
+        ("B6", ("swir_1",)),
+        ("B7", ("swir_2",)),
         ("B8", ("pan",)),
         ("B9", ("cirrus",)),
-        ("B10", ("tirs1",)),
-        ("B11", ("tirs2",)),
+        ("B10", ("tirs_1",)),
+        ("B11", ("tirs_2",)),
     )
 
 class GeoManager:

--- a/yt_geotiff/io.py
+++ b/yt_geotiff/io.py
@@ -79,9 +79,9 @@ class IOHandlerGeoRaster(IOHandlerYTGridHDF5):
         Perform rasterio read and do all transformations and resamples.
         """
 
-        ftype, fname = field
-        filename = self.ds._field_band_map[fname]['filename']
-        band = self.ds._field_band_map[fname]['band']
+        read_info = self.ds.index.geo_manager.fields[field]
+        filename = read_info["filename"]
+        band = read_info["band"]
 
         src = rasterio.open(filename, "r")
 
@@ -104,7 +104,7 @@ class IOHandlerGeoRaster(IOHandlerYTGridHDF5):
         base_resolution = self.ds.resolution.d[0]
         if image_resolution != base_resolution:
             scale_factor = image_resolution / base_resolution
-            mylog.info(f"Resampling {fname}: {image_resolution} to {base_resolution} m.")
+            mylog.info(f"Resampling {field}: {image_resolution} to {base_resolution} m.")
             data = zoom(data, scale_factor, order=0)
 
         # Now clip to the size of the window in the base resolution.

--- a/yt_geotiff/utilities.py
+++ b/yt_geotiff/utilities.py
@@ -179,10 +179,11 @@ def save_as_geotiff(ds, filename, fields=None, data_source=None):
                        ) as dst:
         for i, field in enumerate(fields):
             band = i + 1
+            fname = f"band_{band}"
             ytLogger.info(f"Saving {field} to band {band}/{len(fields)}.")
-            field_info[str(band)] = {"field_type": field[0], "field_name": field[1]}
+            field_info[fname] = {"field_type": field[0], "field_name": field[1]}
             for attr in ["take_log", "units"]:
-                field_info[str(band)][attr] = getattr(ds.field_info[field], attr)
+                field_info[fname][attr] = getattr(ds.field_info[field], attr)
             data = wgrid[field].d[..., 0]
             data[~mask] = 0
             if ds._flip_axes:


### PR DESCRIPTION
This PR is mainly to deal with Issue #29, but in the process I have introduced a new class, the `GeoManager`, which will make it easier to add support for data products from additional satellites. The `GeoManager` class is accompanied by the `GeoImage` class, which defines file naming conventions and band aliases. There are subclasses for Landsat-8 and Sentinel-2, and these should illustrate how one would go about adding more.

This is a major change to the field naming convention. Previous, we defined fields as:
- `("bands", "LS_B10")`
- `("bands", "S2_B8a")`
- `("band_ratios", "NDWI")`
- `("variables", "LS_temperature")`

Now, the field type (i.e., the first item in the tuple) is a string derived from the loaded filenames. For example, if we have loaded "LC08_L2SP_171060_20210227_20210304_02_T1*.tif" and "T36MVE_20210315T075701*.jp2", we will have two field types:
- `"LC08_L2SP_171060_20210227_20210304_02_T1`
- `"T36MVE_20210315T075701"`

Band fields will then be, for example:
- `("LC08_L2SP_171060_20210227_20210304_02_T1", "L8_B10")`
- `("T36MVE_20210315T075701", "S2_B8a")`

Versions of the derived fields will then be available for each field type for which the required bands are available, meaning we could have both of these:
- `("LC08_L2SP_171060_20210227_20210304_02_T1", "NDWI")`
- `("T36MVE_20210315T075701", "NDWI")`

Finally, I have changed the way field names are taken from the field map file. These are no longer done as aliases, but instead as the true name of the field, meaning that `ds.field_list` will show the informative names instead of just "band_1", "band_2", etc.